### PR TITLE
Fix gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,19 +2,7 @@
 * text=auto eol=lf
 
 # Only include the addons folder when downloading from the Asset Library.
-.gdlintrc            export-ignore
-.gitattributes       export-ignore
-.github/             export-ignore
-.gitignore           export-ignore
-.runsettings         export-ignore
-.runsettings-ci      export-ignore
-LICENSE              export-ignore
-README.md            export-ignore
-icon.jpg             export-ignore
-icon.jpg.import      export-ignore
-plugin-updater.json  export-ignore
-project.godot        export-ignore
-scripts/             export-ignore
-test/                export-ignore
-
-addons/gdUnit4       export-ignore
+/**                         export-ignore
+/addons                     !export-ignore
+/addons/plugin_updater      !export-ignore
+/addons/plugin_updater/**   !export-ignore

--- a/addons/plugin_updater/plugin.cfg
+++ b/addons/plugin_updater/plugin.cfg
@@ -3,5 +3,5 @@
 name="plugin_updater"
 description="A plugin for plugin makers to give their plugins an easy in-editor updating."
 author="myyk"
-version="1.1.2"
+version="1.1.3"
 script="plugin_updater.gd"


### PR DESCRIPTION
Simplified the .gitattributes file. This will be easier to maintain.

Tested with: `git archive --format=tar fix-gitattributes | gzip > ~/Downloads/archive.tar.gz` locally and verified that the json file is no longer being ignored.